### PR TITLE
exporter: close reader in error path

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -121,6 +121,7 @@ func (g *Exporter) transmitRecords(stream grpc.BidiStreamingClient[ExportRequest
 			n, err := record.Reader.Read(buf)
 			if n != 0 {
 				if err := sendData(buf[:n]); err != nil {
+					record.Reader.Close()
 					return err
 				}
 			}


### PR DESCRIPTION
In practice if sendData fails we're going to shut down the grpc layer altogether.