### PR TITLE
importer: check before emiting new record if context has been canceled

### DIFF
--- a/importer/importer.go
+++ b/importer/importer.go
@@ -200,7 +200,9 @@ func (g *Importer) receiveRecords(ctx context.Context, stream grpc.BidiStreaming
 			return g.open(ctx, record)
 		})
 
-		records <- record
+		if err := g.emitRecord(ctx, records, record); err != nil {
+			return err
+		}
 	}
 }
 
@@ -234,4 +236,14 @@ func (g *Importer) Import(ctx context.Context, records chan<- *connectors.Record
 	})
 
 	return wg.Wait()
+}
+
+func (imp *Importer) emitRecord(ctx context.Context, records chan<- *connectors.Record, record *connectors.Record) error {
+	select {
+	case <-ctx.Done():
+		_ = record.Close()
+		return ctx.Err()
+	case records <- record:
+	}
+	return nil
 }


### PR DESCRIPTION

This logic is pulled from Proxmox and VMWare integration, basically check context before passing to a (potentially closed) channel

Through having to test sftp and it being stuck, I ran the `GOTRACEBACK=all plakar ....` to see where things go wrong. In the stacktrace I noticed the following:

```
github.com/PlakarKorp/integration-grpc/importer.(*Importer).receiveRecords
.../integration-grpc/importer/importer.go:200
```



The whole shabang:

```pc=0x1033680fc
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x4c fp=0x140007e17d0 sp=0x140007e1760 pc=0x1033677dc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140007e17d0 sp=0x140007e17d0 pc=0x102aa5d04
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 220
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x90

goroutine 242 gp=0x140007dac40 m=nil [select]:
runtime.gopark(0x140007fbec8?, 0x2?, 0xc8?, 0xbc?, 0x140007fbe1c?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140007fbc80 sp=0x140007fbc60 pc=0x102a9d740
runtime.selectgo(0x140007fbec8, 0x140007fbe18, 0xfd47db5080ad16c4?, 0x0, 0x14011c20120?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x140007fbdc0 sp=0x140007fbc80 pc=0x102a7d66c
github.com/PlakarKorp/kloset/repository/packer.(*seqPackerManager).Run.func2()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/repository/packer/packer_seq.go:118 +0xcc fp=0x140007fbf60 sp=0x140007fbdc0 pc=0x1033680fc
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x4c fp=0x140007fbfd0 sp=0x140007fbf60 pc=0x1033677dc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140007fbfd0 sp=0x140007fbfd0 pc=0x102aa5d04
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 220
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x90

goroutine 183 gp=0x140108e8c40 m=nil [chan receive]:
runtime.gopark(0x140006f0608?, 0x140005fb8f0?, 0x0?, 0x0?, 0x14000792090?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140007b4ca0 sp=0x140007b4c80 pc=0x102a9d740
runtime.chanrecv(0x14000172d20, 0x140007b4e70, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:667 +0x428 fp=0x140007b4d20 sp=0x140007b4ca0 pc=0x102a369e8
runtime.chanrecv2(0x1400088c5b0?, 0x104eb2f30?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:514 +0x14 fp=0x140007b4d50 sp=0x140007b4d20 pc=0x102a365a4
github.com/cockroachdb/pebble/v2.(*cleanupManager).mainLoop(0x1400088c5b0)
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/obsolete_files.go:180 +0x100 fp=0x140007b4ef0 sp=0x140007b4d50 pc=0x1032e1ad0
github.com/cockroachdb/pebble/v2.openCleanupManager.func1.1({0x104ea0838?, 0x140002ab470?})
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/obsolete_files.go:112 +0x20 fp=0x140007b4f10 sp=0x140007b4ef0 pc=0x1032e1510
runtime/pprof.Do({0x104ea0918?, 0x105c7cac0?}, {{0x140002e8300?, 0x1400068ebd0?, 0x103340ec0?}}, 0x140108e07b8)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/pprof/runtime.go:51 +0x78 fp=0x140007b4f80 sp=0x140007b4f10 pc=0x102b80568
github.com/cockroachdb/pebble/v2.openCleanupManager.func1()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/obsolete_files.go:111 +0x54 fp=0x140007b4fd0 sp=0x140007b4f80 pc=0x1032e14d4
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140007b4fd0 sp=0x140007b4fd0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2.openCleanupManager in goroutine 224
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/obsolete_files.go:110 +0x1c8

goroutine 223 gp=0x140108e8e00 m=nil [select]:
runtime.gopark(0x140007dd7a8?, 0x2?, 0x28?, 0xd6?, 0x140007dd784?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140007dd5e0 sp=0x140007dd5c0 pc=0x102a9d740
runtime.selectgo(0x140007dd7a8, 0x140007dd780, 0x104e942e0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x140007dd720 sp=0x140007dd5e0 pc=0x102a7d66c
github.com/PlakarKorp/kloset/snapshot.(*Builder).Lock.func1()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/snapshot/builder.go:302 +0xf4 fp=0x140007dd7d0 sp=0x140007dd720 pc=0x1033e5554
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140007dd7d0 sp=0x140007dd7d0 pc=0x102aa5d04
created by github.com/PlakarKorp/kloset/snapshot.(*Builder).Lock in goroutine 1
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/snapshot/builder.go:300 +0x4bc

goroutine 182 gp=0x140111be000 m=nil [select]:
runtime.gopark(0x140108e1790?, 0x2?, 0x88?, 0x15?, 0x140108e16e4?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140108e1540 sp=0x140108e1520 pc=0x102a9d740
runtime.selectgo(0x140108e1790, 0x140108e16e0, 0x105c4ce60?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x140108e1680 sp=0x140108e1540 pc=0x102a7d66c
github.com/cockroachdb/pebble/v2/vfs.(*diskHealthCheckingFS).startTickerLocked.func1()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/vfs/disk_health.go:677 +0xbc fp=0x140108e17d0 sp=0x140108e1680 pc=0x103062fdc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140108e17d0 sp=0x140108e17d0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2/vfs.(*diskHealthCheckingFS).startTickerLocked in goroutine 224
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/vfs/disk_health.go:666 +0x74

goroutine 191 gp=0x140007028c0 m=nil [chan receive]:
runtime.gopark(0x140108e56d8?, 0x103166fb0?, 0x78?, 0xa0?, 0x140108e55e8?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140108e56a0 sp=0x140108e5680 pc=0x102a9d740
runtime.chanrecv(0x14000173180, 0x140108e5780, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:667 +0x428 fp=0x140108e5720 sp=0x140108e56a0 pc=0x102a369e8
runtime.chanrecv2(0x102b805c0?, 0x104ea0918?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:514 +0x14 fp=0x140108e5750 sp=0x140108e5720 pc=0x102a365a4
github.com/cockroachdb/pebble/v2/internal/genericcache.(*shard[...]).releaseLoop(0x140108ea000)
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/internal/genericcache/shard.go:61 +0x68 fp=0x140108e57b0 sp=0x140108e5750 pc=0x10330da58
github.com/cockroachdb/pebble/v2/internal/genericcache.(*shard[...]).Init.gowrap1()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/internal/genericcache/shard.go:54 +0x28 fp=0x140108e57d0 sp=0x140108e57b0 pc=0x10330dcf8
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140108e57d0 sp=0x140108e57d0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2/internal/genericcache.(*shard[...]).Init in goroutine 224
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/internal/genericcache/shard.go:54 +0x15c

goroutine 192 gp=0x14000702a80 m=nil [chan receive]:
runtime.gopark(0x14000776798?, 0x102b9ce70?, 0x48?, 0xdc?, 0x14000559c70?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140007766a0 sp=0x14000776680 pc=0x102a9d740
runtime.chanrecv(0x140001731f0, 0x14000776780, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:667 +0x428 fp=0x14000776720 sp=0x140007766a0 pc=0x102a369e8
runtime.chanrecv2(0x103a48fc0?, 0x140108a8008?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:514 +0x14 fp=0x14000776750 sp=0x14000776720 pc=0x102a365a4
github.com/cockroachdb/pebble/v2/internal/genericcache.(*shard[...]).releaseLoop(0x1400045e690)
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/internal/genericcache/shard.go:61 +0x68 fp=0x140007767b0 sp=0x14000776750 pc=0x10330da58
github.com/cockroachdb/pebble/v2/internal/genericcache.(*shard[...]).Init.gowrap1()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/internal/genericcache/shard.go:54 +0x28 fp=0x140007767d0 sp=0x140007767b0 pc=0x10330dcf8
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140007767d0 sp=0x140007767d0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2/internal/genericcache.(*shard[...]).Init in goroutine 224
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/internal/genericcache/shard.go:54 +0x15c

goroutine 193 gp=0x14000702c40 m=nil [select]:
runtime.gopark(0x14011a53778?, 0x3?, 0x40?, 0x2c?, 0x14011a53762?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011a535e0 sp=0x14011a535c0 pc=0x102a9d740
runtime.selectgo(0x14011a53778, 0x14011a5375c, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011a53720 sp=0x14011a535e0 pc=0x102a7d66c
github.com/cockroachdb/pebble/v2.(*ConcurrencyLimitScheduler).periodicGranter(0x14000405560)
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/compaction_scheduler.go:407 +0x90 fp=0x14011a537b0 sp=0x14011a53720 pc=0x103298c60
github.com/cockroachdb/pebble/v2.(*ConcurrencyLimitScheduler).Register.gowrap1()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/compaction_scheduler.go:303 +0x28 fp=0x14011a537d0 sp=0x14011a537b0 pc=0x1032981a8
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011a537d0 sp=0x14011a537d0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2.(*ConcurrencyLimitScheduler).Register in goroutine 224
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/compaction_scheduler.go:303 +0x8c

goroutine 293 gp=0x14000702e00 m=nil [select]:
runtime.gopark(0x14011a54f90?, 0x2?, 0x28?, 0x4e?, 0x14011a54f6c?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011a54de0 sp=0x14011a54dc0 pc=0x102a9d740
runtime.selectgo(0x14011a54f90, 0x14011a54f68, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011a54f20 sp=0x14011a54de0 pc=0x102a7d66c
github.com/cockroachdb/pebble/v2/vfs.(*diskHealthCheckingFile).startTicker.func1()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/vfs/disk_health.go:254 +0x94 fp=0x14011a54fd0 sp=0x14011a54f20 pc=0x103061844
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011a54fd0 sp=0x14011a54fd0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2/vfs.(*diskHealthCheckingFile).startTicker in goroutine 224
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/vfs/disk_health.go:249 +0x64

goroutine 291 gp=0x14000702fc0 m=nil [select]:
runtime.gopark(0x14011a53f90?, 0x2?, 0x28?, 0x3e?, 0x14011a53f6c?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011a53de0 sp=0x14011a53dc0 pc=0x102a9d740
runtime.selectgo(0x14011a53f90, 0x14011a53f68, 0x102b805c0?, 0x0, 0x105c7cac0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011a53f20 sp=0x14011a53de0 pc=0x102a7d66c
github.com/cockroachdb/pebble/v2/vfs.(*diskHealthCheckingFile).startTicker.func1()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/vfs/disk_health.go:254 +0x94 fp=0x14011a53fd0 sp=0x14011a53f20 pc=0x103061844
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011a53fd0 sp=0x14011a53fd0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2/vfs.(*diskHealthCheckingFile).startTicker in goroutine 290
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/vfs/disk_health.go:249 +0x64

goroutine 294 gp=0x14000703340 m=nil [sync.Cond.Wait]:
runtime.gopark(0x14000580008?, 0x14011a82000?, 0x28?, 0xdd?, 0x102a9fd00?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x1401090dce0 sp=0x1401090dcc0 pc=0x102a9d740
runtime.goparkunlock(...)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:466
sync.runtime_notifyListWait(0x14011b000a8, 0x0)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/sema.go:606 +0x140 fp=0x1401090dd30 sp=0x1401090dce0 pc=0x102a9f0b0
sync.(*Cond).Wait(0x14011b00098)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/sync/cond.go:71 +0xa4 fp=0x1401090dd60 sp=0x1401090dd30 pc=0x102aafa64
github.com/cockroachdb/pebble/v2/record.(*flusherCond).Wait(...)
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/record/log_writer.go:371
github.com/cockroachdb/pebble/v2/record.(*LogWriter).flushLoop(0x14011b00000, {0x104c896e0?, 0x105c7cac0?})
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/record/log_writer.go:673 +0x66c fp=0x1401090dee0 sp=0x1401090dd60 pc=0x103166e6c
github.com/cockroachdb/pebble/v2/record.(*LogWriter).flushLoop-fm({0x104ea0838?, 0x140002ab4a0?})
        <autogenerated>:1 +0x3c fp=0x1401090df10 sp=0x1401090dee0 pc=0x10316bc6c
runtime/pprof.Do({0x104ea0918?, 0x105c7cac0?}, {{0x140002e8120?, 0x0?, 0x0?}}, 0x14011a557b8)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/pprof/runtime.go:51 +0x78 fp=0x1401090df80 sp=0x1401090df10 pc=0x102b80568
github.com/cockroachdb/pebble/v2/record.NewLogWriter.func2()
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/record/log_writer.go:587 +0x54 fp=0x1401090dfd0 sp=0x1401090df80 pc=0x1031667e4
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x1401090dfd0 sp=0x1401090dfd0 pc=0x102aa5d04
created by github.com/cockroachdb/pebble/v2/record.NewLogWriter in goroutine 224
        /_REDACTED/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.4/record/log_writer.go:586 +0x494

goroutine 324 gp=0x14011aa3880 m=nil [chan send]:
runtime.gopark(0x1300700008?, 0x1333c2d08?, 0xc8?, 0xe6?, 0x120?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140007fedb0 sp=0x140007fed90 pc=0x102a9d740
runtime.chansend(0x140002c20e0, 0x140007fee80, 0x1, 0x103468bf4?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:283 +0x394 fp=0x140007fee20 sp=0x140007fedb0 pc=0x102a35ad4
runtime.chansend1(0x140007fee88?, 0x10346a158?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:161 +0x18 fp=0x140007fee50 sp=0x140007fee20 pc=0x102a35728
github.com/PlakarKorp/plakar/subcommands/backup.ack(0x14004134360, 0x140002c20e0)
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:521 +0xb8 fp=0x140007fee90 sp=0x140007fee50 pc=0x103468c18
github.com/PlakarKorp/plakar/subcommands/backup.statistics.func1(0x140002c2070, 0x140002c20e0)
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:646 +0x80 fp=0x140007fefa0 sp=0x140007fee90 pc=0x10346a170
github.com/PlakarKorp/plakar/subcommands/backup.progress.func1()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:538 +0x34 fp=0x140007fefd0 sp=0x140007fefa0 pc=0x103468de4
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140007fefd0 sp=0x140007fefd0 pc=0x102aa5d04
created by github.com/PlakarKorp/plakar/subcommands/backup.progress in goroutine 340
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:537 +0xe8

goroutine 340 gp=0x14011aa3a40 m=nil [chan receive]:
runtime.gopark(0x14011aa3a40?, 0x103367770?, 0xa8?, 0xdd?, 0x103aa69e8?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14000885d60 sp=0x14000885d40 pc=0x102a9d740
runtime.chanrecv(0x14011c5e380, 0x0, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:667 +0x428 fp=0x14000885de0 sp=0x14000885d60 pc=0x102a369e8
runtime.chanrecv1(0x140001ffa40?, 0x104ea0800?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:509 +0x14 fp=0x14000885e10 sp=0x14000885de0 pc=0x102a36584
github.com/PlakarKorp/plakar/subcommands/backup.progress(0x140005b0c00, {0x104ea8e30, 0x140001ffa40}, 0x140001687c0)
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:546 +0x124 fp=0x14000885e80 sp=0x14000885e10 pc=0x103468d74
github.com/PlakarKorp/plakar/subcommands/backup.statistics(0x140005b0c00, 0x140006e8600)
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:644 +0xc8 fp=0x14000885f30 sp=0x14000885e80 pc=0x103469fd8
github.com/PlakarKorp/plakar/subcommands/backup.(*Backup).DoBackup.func1()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:398 +0x2c fp=0x14000885fd0 sp=0x14000885f30 pc=0x1034682fc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14000885fd0 sp=0x14000885fd0 pc=0x102aa5d04
created by github.com/PlakarKorp/plakar/subcommands/backup.(*Backup).DoBackup in goroutine 1
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/plakar@v1.0.4-0.20260413080115-49829ee8bfeb/subcommands/backup/backup.go:397 +0x1268

goroutine 341 gp=0x14011aa3c00 m=nil [select]:
runtime.gopark(0x14011aab778?, 0x2?, 0x38?, 0xb6?, 0x14011aab774?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011aab5f0 sp=0x14011aab5d0 pc=0x102a9d740
runtime.selectgo(0x14011aab778, 0x14011aab770, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011aab730 sp=0x14011aab5f0 pc=0x102a7d66c
database/sql.(*DB).connectionOpener(0x140007c64e0, {0x104ea0870, 0x14011ab6b40})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:1261 +0x80 fp=0x14011aab7a0 sp=0x14011aab730 pc=0x102c52180
database/sql.OpenDB.gowrap1()
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x2c fp=0x14011aab7d0 sp=0x14011aab7a0 pc=0x102c5043c
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011aab7d0 sp=0x14011aab7d0 pc=0x102aa5d04
created by database/sql.OpenDB in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x114

goroutine 342 gp=0x14011aa3dc0 m=nil [select]:
runtime.gopark(0x14011aac778?, 0x2?, 0x0?, 0x0?, 0x14011aac774?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011aac5f0 sp=0x14011aac5d0 pc=0x102a9d740
runtime.selectgo(0x14011aac778, 0x14011aac770, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011aac730 sp=0x14011aac5f0 pc=0x102a7d66c
database/sql.(*DB).connectionOpener(0x140007c68f0, {0x104ea0870, 0x14011ab6b90})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:1261 +0x80 fp=0x14011aac7a0 sp=0x14011aac730 pc=0x102c52180
database/sql.OpenDB.gowrap1()
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x2c fp=0x14011aac7d0 sp=0x14011aac7a0 pc=0x102c5043c
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011aac7d0 sp=0x14011aac7d0 pc=0x102aa5d04
created by database/sql.OpenDB in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x114

goroutine 343 gp=0x14011aea000 m=nil [select]:
runtime.gopark(0x14011aacf78?, 0x2?, 0x0?, 0x0?, 0x14011aacf74?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011aacdf0 sp=0x14011aacdd0 pc=0x102a9d740
runtime.selectgo(0x14011aacf78, 0x14011aacf70, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011aacf30 sp=0x14011aacdf0 pc=0x102a7d66c
database/sql.(*DB).connectionOpener(0x140007c6d00, {0x104ea0870, 0x14011ab6be0})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:1261 +0x80 fp=0x14011aacfa0 sp=0x14011aacf30 pc=0x102c52180
database/sql.OpenDB.gowrap1()
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x2c fp=0x14011aacfd0 sp=0x14011aacfa0 pc=0x102c5043c
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011aacfd0 sp=0x14011aacfd0 pc=0x102aa5d04
created by database/sql.OpenDB in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x114

goroutine 344 gp=0x14011aea1c0 m=nil [select]:
runtime.gopark(0x14011af3778?, 0x2?, 0x0?, 0x0?, 0x14011af3774?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011af35f0 sp=0x14011af35d0 pc=0x102a9d740
runtime.selectgo(0x14011af3778, 0x14011af3770, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011af3730 sp=0x14011af35f0 pc=0x102a7d66c
database/sql.(*DB).connectionOpener(0x140007c7110, {0x104ea0870, 0x14011ab6c30})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:1261 +0x80 fp=0x14011af37a0 sp=0x14011af3730 pc=0x102c52180
database/sql.OpenDB.gowrap1()
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x2c fp=0x14011af37d0 sp=0x14011af37a0 pc=0x102c5043c
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011af37d0 sp=0x14011af37d0 pc=0x102aa5d04
created by database/sql.OpenDB in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x114

goroutine 345 gp=0x14011aea380 m=nil [select]:
runtime.gopark(0x14011af3f78?, 0x2?, 0x0?, 0x0?, 0x14011af3f74?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011af3df0 sp=0x14011af3dd0 pc=0x102a9d740
runtime.selectgo(0x14011af3f78, 0x14011af3f70, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011af3f30 sp=0x14011af3df0 pc=0x102a7d66c
database/sql.(*DB).connectionOpener(0x140007c7520, {0x104ea0870, 0x14011ab6c80})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:1261 +0x80 fp=0x14011af3fa0 sp=0x14011af3f30 pc=0x102c52180
database/sql.OpenDB.gowrap1()
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x2c fp=0x14011af3fd0 sp=0x14011af3fa0 pc=0x102c5043c
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011af3fd0 sp=0x14011af3fd0 pc=0x102aa5d04
created by database/sql.OpenDB in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x114

goroutine 346 gp=0x14011aea540 m=nil [select]:
runtime.gopark(0x14011af4778?, 0x2?, 0x0?, 0x0?, 0x14011af4774?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011af45f0 sp=0x14011af45d0 pc=0x102a9d740
runtime.selectgo(0x14011af4778, 0x14011af4770, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011af4730 sp=0x14011af45f0 pc=0x102a7d66c
database/sql.(*DB).connectionOpener(0x140007c7930, {0x104ea0870, 0x14011ab6cd0})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:1261 +0x80 fp=0x14011af47a0 sp=0x14011af4730 pc=0x102c52180
database/sql.OpenDB.gowrap1()
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x2c fp=0x14011af47d0 sp=0x14011af47a0 pc=0x102c5043c
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011af47d0 sp=0x14011af47d0 pc=0x102aa5d04
created by database/sql.OpenDB in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x114

goroutine 347 gp=0x14011aea700 m=nil [select]:
runtime.gopark(0x14011af4f78?, 0x2?, 0x0?, 0x0?, 0x14011af4f74?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011af4df0 sp=0x14011af4dd0 pc=0x102a9d740
runtime.selectgo(0x14011af4f78, 0x14011af4f70, 0x0?, 0x0, 0x0?, 0x1)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/select.go:351 +0x6bc fp=0x14011af4f30 sp=0x14011af4df0 pc=0x102a7d66c
database/sql.(*DB).connectionOpener(0x140007c7d40, {0x104ea0870, 0x14011ab6d20})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:1261 +0x80 fp=0x14011af4fa0 sp=0x14011af4f30 pc=0x102c52180
database/sql.OpenDB.gowrap1()
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x2c fp=0x14011af4fd0 sp=0x14011af4fa0 pc=0x102c5043c
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011af4fd0 sp=0x14011af4fd0 pc=0x102aa5d04
created by database/sql.OpenDB in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/database/sql/sql.go:841 +0x114

goroutine 348 gp=0x14011aea8c0 m=nil [chan send]:
runtime.gopark(0x1300795d78?, 0x131966278?, 0xe8?, 0xd3?, 0x120?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14017795d40 sp=0x14017795d20 pc=0x102a9d740
runtime.chansend(0x140006cbf10, 0x14017795f28, 0x1, 0x1033d92ac?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:283 +0x394 fp=0x14017795db0 sp=0x14017795d40 pc=0x102a35ad4
runtime.chansend1(0x140000aa300?, 0x103bb49c2?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:161 +0x18 fp=0x14017795de0 sp=0x14017795db0 pc=0x102a35728
github.com/PlakarKorp/kloset/snapshot.(*Builder).importSource.func1()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/snapshot/backup.go:265 +0x614 fp=0x14017795f60 sp=0x14017795de0 pc=0x1033d92d4
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x4c fp=0x14017795fd0 sp=0x14017795f60 pc=0x1033677dc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14017795fd0 sp=0x14017795fd0 pc=0x102aa5d04
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x90

goroutine 352 gp=0x14011aeafc0 m=nil [chan send]:
runtime.gopark(0x1300a5bd78?, 0x1332b4230?, 0xa0?, 0xd8?, 0x120?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14012a5bd40 sp=0x14012a5bd20 pc=0x102a9d740
runtime.chansend(0x140006cbf10, 0x14012a5bf28, 0x1, 0x1033d92ac?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:283 +0x394 fp=0x14012a5bdb0 sp=0x14012a5bd40 pc=0x102a35ad4
runtime.chansend1(0x140000aa300?, 0x103bb49c2?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:161 +0x18 fp=0x14012a5bde0 sp=0x14012a5bdb0 pc=0x102a35728
github.com/PlakarKorp/kloset/snapshot.(*Builder).importSource.func1()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/snapshot/backup.go:265 +0x614 fp=0x14012a5bf60 sp=0x14012a5bde0 pc=0x1033d92d4
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x4c fp=0x14012a5bfd0 sp=0x14012a5bf60 pc=0x1033677dc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14012a5bfd0 sp=0x14012a5bfd0 pc=0x102aa5d04
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x90

goroutine 353 gp=0x14011aeb180 m=nil [chan send]:
runtime.gopark(0x130056fd78?, 0x1330caee8?, 0x78?, 0xca?, 0x120?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x1401756fd40 sp=0x1401756fd20 pc=0x102a9d740
runtime.chansend(0x140006cbf10, 0x1401756ff28, 0x1, 0x1033d92ac?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:283 +0x394 fp=0x1401756fdb0 sp=0x1401756fd40 pc=0x102a35ad4
runtime.chansend1(0x140000aa300?, 0x103bb49c2?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:161 +0x18 fp=0x1401756fde0 sp=0x1401756fdb0 pc=0x102a35728
github.com/PlakarKorp/kloset/snapshot.(*Builder).importSource.func1()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/snapshot/backup.go:265 +0x614 fp=0x1401756ff60 sp=0x1401756fde0 pc=0x1033d92d4
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x4c fp=0x1401756ffd0 sp=0x1401756ff60 pc=0x1033677dc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x1401756ffd0 sp=0x1401756ffd0 pc=0x102aa5d04
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x90

goroutine 357 gp=0x14011aeb880 m=nil [sync.WaitGroup.Wait]:
runtime.gopark(0x105c5f8e0?, 0x0?, 0x80?, 0x50?, 0x0?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x14011af1ea0 sp=0x14011af1e80 pc=0x102a9d740
runtime.goparkunlock(...)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:466
runtime.semacquire1(0x14000178ed0, 0x0, 0x1, 0x0, 0x19)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/sema.go:192 +0x204 fp=0x14011af1ef0 sp=0x14011af1ea0 pc=0x102a7e414
sync.runtime_SemacquireWaitGroup(0x0?, 0x0?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/sema.go:114 +0x38 fp=0x14011af1f30 sp=0x14011af1ef0 pc=0x102a9ee68
sync.(*WaitGroup).Wait(0x14000178ec8)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/sync/waitgroup.go:206 +0xa8 fp=0x14011af1f60 sp=0x14011af1f30 pc=0x102ab1d08
golang.org/x/sync/errgroup.(*Group).Wait(0x14000178ec0)
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:56 +0x28 fp=0x14011af1f80 sp=0x14011af1f60 pc=0x103367698
github.com/PlakarKorp/kloset/snapshot.(*Builder).importSource.func2()
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/snapshot/backup.go:277 +0x30 fp=0x14011af1fd0 sp=0x14011af1f80 pc=0x1033d8c50
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x14011af1fd0 sp=0x14011af1fd0 pc=0x102aa5d04
created by github.com/PlakarKorp/kloset/snapshot.(*Builder).importSource in goroutine 1
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/kloset@v1.1.0-beta.6.0.20260407081142-583ca7aa0373/snapshot/backup.go:276 +0x354

goroutine 359 gp=0x14011aebc00 m=nil [chan send]:
runtime.gopark(0x500000000?, 0x1332f5768?, 0x8?, 0xc1?, 0x30?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/proc.go:460 +0xc0 fp=0x140111c9df0 sp=0x140111c9dd0 pc=0x102a9d740
runtime.chansend(0x140006cbe30, 0x140111c9f08, 0x1, 0x104eacd60?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:283 +0x394 fp=0x140111c9e60 sp=0x140111c9df0 pc=0x102a35ad4
runtime.chansend1(0x14003f473f0?, 0x0?)
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/chan.go:161 +0x18 fp=0x140111c9e90 sp=0x140111c9e60 pc=0x102a35728
------------------------------------------------ WARNING ------------------------------------------------ 
github.com/PlakarKorp/integration-grpc/importer.(*Importer).receiveRecords(0x14000811080, {0x104ea0c18, 0x140003ee000}, {0x104eaaa18, 0x14011ab5150}, 0x140006cbe30)
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/integration-grpc@v1.1.0-beta.3/importer/importer.go:200 +0x74 fp=0x140111c9f20 sp=0x140111c9e90 pc=0x103aa64e4
github.com/PlakarKorp/integration-grpc/importer.(*Importer).Import.func1()
------------------------------------------------  WARNING ------------------------------------------------ 
        /_REDACTED/go/pkg/mod/github.com/!plakar!korp/integration-grpc@v1.1.0-beta.3/importer/importer.go:226 +0x28 fp=0x140111c9f60 sp=0x140111c9f20 pc=0x103aa6aa8
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:93 +0x4c fp=0x140111c9fd0 sp=0x140111c9f60 pc=0x1033677dc
runtime.goexit({})
        /_REDACTED/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.darwin-arm64/src/runtime/asm_arm64.s:1268 +0x4 fp=0x140111c9fd0 sp=0x140111c9fd0 pc=0x102aa5d04
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        /_REDACTED/go/pkg/mod/golang.org/x/sync@v0.20.0/errgroup/errgroup.go:78 +0x90

r0      0x104
r1      0x0
r2      0x2d00
r3      0x0
r4      0x0
r5      0xa0
r6      0x0
r7      0x0
r8      0x16d3d9ff8
r9      0x0
r10     0x100
r11     0x10000000102
r12     0x10000000102
r13     0x100
r14     0x0
r15     0x10000000100
r16     0x131
r17     0x207430948
r18     0x0
r19     0x105c50828
r20     0x105c50868
r21     0x205e72d20
r22     0x0
r23     0x0
r24     0x2d00
r25     0x2e01
r26     0x2f00
r27     0x105b34000
r28     0x105c4d9e0
r29     0x16d3da070
lr      0x198f520dc
sp      0x16d3d9fe0
pc      0x198f124f8
fault   0x198f124f8```