### PR TITLE
importer: Drain the channel when transport fails.

### DIFF
--- a/importer/importer.go
+++ b/importer/importer.go
@@ -210,6 +210,11 @@ func (g *Importer) sendResults(stream grpc.BidiStreamingClient[ImportRequest, Im
 			Result: gconn.ResultToProto(result),
 		}
 		if err := stream.Send(&hdr); err != nil {
+			for range results {
+				// The underlying transport died we still need to drain the
+				// channel or we will deadlock
+			}
+
 			return err
 		}
 	}


### PR DESCRIPTION
* When the transport fails (due to an abort for example) we still need to drain the results channel in order to not deadlock the other side.