### PR TITLE
add tests covering conv, readers, importer, exporter and storage

### DIFF
--- a/conv_test.go
+++ b/conv_test.go
@@ -1,0 +1,172 @@
+package integration_grpc
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/objects"
+)
+
+func sampleFileInfo() objects.FileInfo {
+	return objects.FileInfo{
+		Lname:      "hello.txt",
+		Lsize:      1234,
+		Lmode:      0o644,
+		LmodTime:   time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Ldev:       1,
+		Lino:       2,
+		Luid:       1000,
+		Lgid:       1000,
+		Lnlink:     1,
+		Lusername:  "alice",
+		Lgroupname: "users",
+		Flags:      0x42,
+	}
+}
+
+func TestRecordRoundTrip_Regular(t *testing.T) {
+	rec := &connectors.Record{
+		Pathname: "/etc/hello.txt",
+		FileInfo: sampleFileInfo(),
+		Target:   "",
+		ExtendedAttributes: []string{"user.foo", "user.bar"},
+		FileAttributes:     0xdead,
+		Reader:             io.NopCloser(strings.NewReader("xx")),
+	}
+
+	pb := RecordToProto(rec)
+	if !pb.HasReader {
+		t.Fatalf("regular file with reader should have HasReader=true")
+	}
+
+	got, err := RecordFromProto(pb)
+	if err != nil {
+		t.Fatalf("RecordFromProto: %v", err)
+	}
+	if got.Pathname != rec.Pathname {
+		t.Errorf("pathname mismatch: %q vs %q", got.Pathname, rec.Pathname)
+	}
+	if !got.FileInfo.Equal(&rec.FileInfo) {
+		t.Errorf("fileinfo mismatch: %+v vs %+v", got.FileInfo, rec.FileInfo)
+	}
+	if got.FileAttributes != rec.FileAttributes {
+		t.Errorf("fileattributes mismatch")
+	}
+}
+
+func TestRecordRoundTrip_ErrorSkipsFileInfo(t *testing.T) {
+	rec := &connectors.Record{
+		Pathname: "/missing",
+		Err:      errors.New("ENOENT"),
+	}
+
+	pb := RecordToProto(rec)
+	if pb.FileInfo != nil {
+		t.Errorf("error record should not have FileInfo serialised")
+	}
+	if pb.HasReader {
+		t.Errorf("error record should not advertise HasReader")
+	}
+	if pb.Error != "ENOENT" {
+		t.Errorf("error string lost: %q", pb.Error)
+	}
+
+	got, err := RecordFromProto(pb)
+	if err != nil {
+		t.Fatalf("RecordFromProto: %v", err)
+	}
+	if got.Err == nil || got.Err.Error() != "ENOENT" {
+		t.Errorf("error not round-tripped: %v", got.Err)
+	}
+}
+
+func TestRecordRoundTrip_Xattr(t *testing.T) {
+	rec := &connectors.Record{
+		Pathname:  "/etc/hello.txt",
+		IsXattr:   true,
+		XattrName: "user.comment",
+		XattrType: objects.AttributeExtended,
+		Reader:    io.NopCloser(strings.NewReader("data")),
+	}
+
+	pb := RecordToProto(rec)
+	if pb.FileInfo != nil {
+		t.Errorf("xattr record should not include FileInfo")
+	}
+	if !pb.HasReader {
+		t.Errorf("xattr record with a Reader should have HasReader=true")
+	}
+
+	got, err := RecordFromProto(pb)
+	if err != nil {
+		t.Fatalf("RecordFromProto: %v", err)
+	}
+	if !got.IsXattr || got.XattrName != "user.comment" {
+		t.Errorf("xattr fields lost: %+v", got)
+	}
+}
+
+func TestRecordFromProto_MissingFileInfoIsError(t *testing.T) {
+	// Regular (non-xattr, no error) record arriving with no FileInfo
+	// must fail rather than silently produce a zero FileInfo.
+	bad := &Record{
+		Pathname: "/somewhere",
+	}
+	if _, err := RecordFromProto(bad); !errors.Is(err, ErrInvalidRecord) {
+		t.Fatalf("expected ErrInvalidRecord, got %v", err)
+	}
+}
+
+func TestRecordToProto_NoReader_DirectoryHasNoReader(t *testing.T) {
+	rec := &connectors.Record{
+		Pathname: "/etc",
+		FileInfo: objects.FileInfo{
+			Lname: "etc",
+			Lmode: fs.ModeDir | 0o755,
+		},
+	}
+	pb := RecordToProto(rec)
+	if pb.HasReader {
+		t.Errorf("directory record should not advertise a reader")
+	}
+}
+
+func TestRecordToProto_RegularButNilReader(t *testing.T) {
+	rec := &connectors.Record{
+		Pathname: "/etc/hello.txt",
+		FileInfo: sampleFileInfo(),
+	}
+	pb := RecordToProto(rec)
+	if pb.HasReader {
+		t.Errorf("nil reader should yield HasReader=false")
+	}
+}
+
+func TestResultRoundTrip(t *testing.T) {
+	r := &connectors.Result{
+		Record: connectors.Record{
+			Pathname: "/etc/hello.txt",
+			FileInfo: sampleFileInfo(),
+		},
+		Err: errors.New("boom"),
+	}
+	pb := ResultToProto(r)
+	if pb.Error != "boom" {
+		t.Errorf("error lost: %q", pb.Error)
+	}
+	got, err := ResultFromProto(pb)
+	if err != nil {
+		t.Fatalf("ResultFromProto: %v", err)
+	}
+	if got.Err == nil || got.Err.Error() != "boom" {
+		t.Errorf("result error lost: %v", got.Err)
+	}
+	if got.Record.Pathname != r.Record.Pathname {
+		t.Errorf("record pathname lost")
+	}
+}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -1,0 +1,256 @@
+package exporter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	gconn "github.com/PlakarKorp/integration-grpc"
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/objects"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// ---------------------------------------------------------------------------
+// Fake server
+// ---------------------------------------------------------------------------
+
+type fakeServer struct {
+	UnimplementedExporterServer
+
+	mu       sync.Mutex
+	received []receivedFile
+
+	respond []*connectors.Result
+}
+
+type receivedFile struct {
+	record  *gconn.Record
+	payload []byte
+}
+
+func (f *fakeServer) Init(ctx context.Context, req *InitRequest) (*InitResponse, error) {
+	return &InitResponse{Origin: "o", Type: "t", Root: "/", Flags: 0}, nil
+}
+func (f *fakeServer) Ping(ctx context.Context, _ *PingRequest) (*PingResponse, error) {
+	return &PingResponse{}, nil
+}
+func (f *fakeServer) Close(ctx context.Context, _ *CloseRequest) (*CloseResponse, error) {
+	return &CloseResponse{}, nil
+}
+
+func (f *fakeServer) Export(stream grpc.BidiStreamingServer[ExportRequest, ExportResponse]) error {
+	var current *gconn.Record
+	var buf bytes.Buffer
+
+	// Pre-queue any responses to send after we see at least one record.
+	pending := append([]*connectors.Result(nil), f.respond...)
+
+	flush := func() {
+		f.mu.Lock()
+		f.received = append(f.received, receivedFile{
+			record:  current,
+			payload: append([]byte(nil), buf.Bytes()...),
+		})
+		f.mu.Unlock()
+		current = nil
+		buf.Reset()
+	}
+
+	for {
+		req, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		switch p := req.Packet.(type) {
+		case *ExportRequest_Record:
+			if current != nil {
+				flush()
+			}
+			current = p.Record
+			if !p.Record.HasReader {
+				flush()
+			}
+		case *ExportRequest_Chunk:
+			if len(p.Chunk) == 0 {
+				// terminator chunk (client sends a zero-length chunk
+				// after each file; protobuf may unmarshal nil as []byte{})
+				flush()
+			} else {
+				buf.Write(p.Chunk)
+			}
+		}
+
+		// echo back a result for each completed file, draining the
+		// `pending` list (if any was supplied).
+		f.mu.Lock()
+		for len(pending) > 0 && len(f.received) > 0 {
+			r := pending[0]
+			pending = pending[1:]
+			if err := stream.Send(&ExportResponse{Result: gconn.ResultToProto(r)}); err != nil {
+				f.mu.Unlock()
+				return err
+			}
+		}
+		f.mu.Unlock()
+	}
+	if current != nil {
+		flush()
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// scaffolding
+// ---------------------------------------------------------------------------
+
+func dialTestServer(t *testing.T, srv *fakeServer) (*grpc.ClientConn, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	s := grpc.NewServer()
+	RegisterExporterServer(s, srv)
+	go func() { _ = s.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough://bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return conn, func() {
+		_ = conn.Close()
+		s.Stop()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestExporter_InitAndGetters(t *testing.T) {
+	conn, cleanup := dialTestServer(t, &fakeServer{})
+	defer cleanup()
+
+	exp, err := NewExporter(context.Background(), conn, &connectors.Options{}, "p", nil)
+	if err != nil {
+		t.Fatalf("NewExporter: %v", err)
+	}
+	if exp.Origin() != "o" || exp.Type() != "t" || exp.Root() != "/" {
+		t.Errorf("getters: %q %q %q", exp.Origin(), exp.Type(), exp.Root())
+	}
+}
+
+func TestExporter_SendsRecordAndChunks(t *testing.T) {
+	srv := &fakeServer{
+		respond: []*connectors.Result{
+			{Record: connectors.Record{Pathname: "/a.txt"}},
+		},
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	exp, err := NewExporter(context.Background(), conn, &connectors.Options{}, "p", nil)
+	if err != nil {
+		t.Fatalf("NewExporter: %v", err)
+	}
+
+	payload := bytes.Repeat([]byte("ab"), 100)
+	rec := &connectors.Record{
+		Pathname: "/a.txt",
+		FileInfo: objects.FileInfo{
+			Lname: "a.txt",
+			Lsize: int64(len(payload)),
+			Lmode: 0o644,
+		},
+		Reader: io.NopCloser(bytes.NewReader(payload)),
+	}
+
+	records := make(chan *connectors.Record, 1)
+	results := make(chan *connectors.Result, 1)
+	records <- rec
+	close(records)
+
+	done := make(chan error, 1)
+	go func() { done <- exp.Export(context.Background(), records, results) }()
+
+	// Drain results.
+	gotResult := false
+	for r := range results {
+		if r == nil {
+			t.Fatalf("nil result")
+		}
+		gotResult = true
+	}
+	if !gotResult {
+		t.Errorf("expected at least one result from server")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for Export")
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if len(srv.received) != 1 {
+		t.Fatalf("server saw %d files, want 1", len(srv.received))
+	}
+	if !bytes.Equal(srv.received[0].payload, payload) {
+		t.Errorf("payload mismatch: got %d bytes, want %d", len(srv.received[0].payload), len(payload))
+	}
+}
+
+func TestExporter_DirectoryRecordSkipsChunks(t *testing.T) {
+	srv := &fakeServer{}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	exp, err := NewExporter(context.Background(), conn, &connectors.Options{}, "p", nil)
+	if err != nil {
+		t.Fatalf("NewExporter: %v", err)
+	}
+
+	rec := &connectors.Record{
+		Pathname: "/d",
+		FileInfo: objects.FileInfo{
+			Lname: "d",
+			Lmode: 0o755 | 0x80000000, // dir bit
+		},
+	}
+
+	records := make(chan *connectors.Record, 1)
+	results := make(chan *connectors.Result, 1)
+	records <- rec
+	close(records)
+
+	done := make(chan error, 1)
+	go func() { done <- exp.Export(context.Background(), records, results) }()
+
+	for range results {
+	}
+	<-done
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if len(srv.received) != 1 || len(srv.received[0].payload) != 0 {
+		t.Errorf("expected one empty-payload record, got %+v", srv.received)
+	}
+}

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -1,0 +1,295 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	gconn "github.com/PlakarKorp/integration-grpc"
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/objects"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// ---------------------------------------------------------------------------
+// fakeServer implements ImporterServer in-process for tests.
+// ---------------------------------------------------------------------------
+
+type fakeServer struct {
+	UnimplementedImporterServer
+
+	initResp *InitResponse
+	initErr  error
+
+	pingErr error
+
+	// records to emit on Import (server-side)
+	records []*gconn.Record
+	// chunks to emit on Open(record)
+	openChunks map[string][][]byte
+	openErr    error
+
+	// captured Acks from the client
+	acks    []*gconn.Result
+	ackDone chan struct{} // closed when Import returns server-side
+
+	closeErr error
+}
+
+func (f *fakeServer) Init(ctx context.Context, req *InitRequest) (*InitResponse, error) {
+	if f.initErr != nil {
+		return nil, f.initErr
+	}
+	return f.initResp, nil
+}
+
+func (f *fakeServer) Ping(ctx context.Context, _ *PingRequest) (*PingResponse, error) {
+	return &PingResponse{}, f.pingErr
+}
+
+func (f *fakeServer) Close(ctx context.Context, _ *CloseRequest) (*CloseResponse, error) {
+	return &CloseResponse{}, f.closeErr
+}
+
+func (f *fakeServer) Import(stream grpc.BidiStreamingServer[ImportRequest, ImportResponse]) error {
+	if f.ackDone != nil {
+		defer close(f.ackDone)
+	}
+	for _, r := range f.records {
+		if err := stream.Send(&ImportResponse{Record: r}); err != nil {
+			return err
+		}
+	}
+	if err := stream.Send(&ImportResponse{Finished: true}); err != nil {
+		return err
+	}
+
+	for {
+		req, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if req.Result != nil {
+			res, _ := gconn.ResultFromProto(req.Result)
+			f.acks = append(f.acks, &gconn.Result{
+				Header: gconn.RecordToProto(&res.Record),
+			})
+		}
+	}
+}
+
+func (f *fakeServer) Open(req *OpenRequest, stream grpc.ServerStreamingServer[OpenResponse]) error {
+	if f.openErr != nil {
+		return f.openErr
+	}
+	chunks := f.openChunks[req.Record.Pathname]
+	for _, c := range chunks {
+		if err := stream.Send(&OpenResponse{Chunk: c}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// scaffolding
+// ---------------------------------------------------------------------------
+
+func dialTestServer(t *testing.T, srv *fakeServer) (*grpc.ClientConn, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	s := grpc.NewServer()
+	RegisterImporterServer(s, srv)
+	go func() { _ = s.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough://bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return conn, func() {
+		_ = conn.Close()
+		s.Stop()
+	}
+}
+
+func sampleFI() *gconn.FileInfo {
+	return &gconn.FileInfo{
+		Name:    "x.txt",
+		Size:    3,
+		Mode:    0o644,
+		ModTime: nil, // ModTime is not nil-safe upstream; test uses helper below
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestImporter_InitAndGetters(t *testing.T) {
+	srv := &fakeServer{
+		initResp: &InitResponse{
+			Origin: "o",
+			Type:   "t",
+			Root:   "/r",
+			Flags:  0,
+		},
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	imp, err := NewImporter(context.Background(), conn, &connectors.Options{}, "proto", nil)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+	if imp.Origin() != "o" || imp.Type() != "t" || imp.Root() != "/r" {
+		t.Errorf("getters mismatch: %q %q %q", imp.Origin(), imp.Type(), imp.Root())
+	}
+	// FLAG_NEEDACK is always OR'd in.
+	if imp.Flags() == 0 {
+		t.Errorf("expected FLAG_NEEDACK to be set, got 0")
+	}
+	if err := imp.Ping(context.Background()); err != nil {
+		t.Errorf("Ping: %v", err)
+	}
+	if err := imp.Close(context.Background()); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestImporter_Init_UnwrapsErrors(t *testing.T) {
+	srv := &fakeServer{
+		initErr: status.Error(codes.Unavailable, "down"),
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	_, err := NewImporter(context.Background(), conn, &connectors.Options{}, "p", nil)
+	if err == nil || !strings.Contains(err.Error(), "I/O error") {
+		t.Fatalf("expected Unavailable to be wrapped as I/O error, got %v", err)
+	}
+}
+
+func TestImporter_Init_CanceledMapsToContextCanceled(t *testing.T) {
+	srv := &fakeServer{
+		initErr: status.Error(codes.Canceled, "ctx"),
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	_, err := NewImporter(context.Background(), conn, &connectors.Options{}, "p", nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestImporter_ImportStreamsRecordsAndAcks(t *testing.T) {
+	rec := &connectors.Record{
+		Pathname: "/a.txt",
+		FileInfo: objects.FileInfo{
+			Lname: "a.txt",
+			Lsize: 5,
+			Lmode: 0o644,
+		},
+	}
+	pbrec := gconn.RecordToProto(rec)
+
+	srv := &fakeServer{
+		initResp:   &InitResponse{Type: "t", Root: "/"},
+		records:    []*gconn.Record{pbrec},
+		openChunks: map[string][][]byte{"/a.txt": {[]byte("hello")}},
+		ackDone:    make(chan struct{}),
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	imp, err := NewImporter(context.Background(), conn, &connectors.Options{}, "p", nil)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	records := make(chan *connectors.Record, 4)
+	results := make(chan *connectors.Result, 4)
+
+	importDone := make(chan error, 1)
+	go func() { importDone <- imp.Import(context.Background(), records, results) }()
+
+	var got *connectors.Record
+	select {
+	case got = <-records:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for record")
+	}
+	if got == nil || got.Pathname != "/a.txt" {
+		t.Fatalf("unexpected record: %+v", got)
+	}
+
+	// Open via LazyReader
+	data, err := io.ReadAll(got.Reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("payload mismatch: %q", data)
+	}
+	_ = got.Reader.Close()
+
+	// ACK
+	results <- &connectors.Result{Record: *got}
+	close(results)
+
+	if err := <-importDone; err != nil {
+		t.Fatalf("Import returned: %v", err)
+	}
+
+	// Wait for the server to finish its Import handler so it has actually
+	// drained the ack stream — Import returns as soon as the client side
+	// CloseSends, but the server may still be receiving.
+	select {
+	case <-srv.ackDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for server import handler to exit")
+	}
+	if len(srv.acks) != 1 {
+		t.Errorf("server saw %d acks, want 1", len(srv.acks))
+	}
+}
+
+func TestImporter_OpenErrorPropagates(t *testing.T) {
+	srv := &fakeServer{
+		initResp: &InitResponse{},
+		openErr:  status.Error(codes.NotFound, "nope"),
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	imp, err := NewImporter(context.Background(), conn, &connectors.Options{}, "p", nil)
+	if err != nil {
+		t.Fatalf("NewImporter: %v", err)
+	}
+
+	gi := imp.(*Importer)
+	rd, err := gi.open(context.Background(), &connectors.Record{Pathname: "/missing"})
+	if err != nil {
+		t.Fatalf("open returned err immediately: %v", err)
+	}
+	defer rd.Close()
+	if _, err := io.ReadAll(rd); err == nil {
+		t.Fatalf("expected read error from server, got nil")
+	}
+}

--- a/readers_test.go
+++ b/readers_test.go
@@ -1,0 +1,146 @@
+package integration_grpc
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors"
+	"github.com/PlakarKorp/kloset/objects"
+)
+
+type countingReadCloser struct {
+	io.Reader
+	closed atomic.Bool
+	err    error
+}
+
+func (c *countingReadCloser) Close() error {
+	c.closed.Store(true)
+	return c.err
+}
+
+func TestHoldingReaders_TrackGetDelete(t *testing.T) {
+	h := NewHoldingReaders()
+
+	rc := &countingReadCloser{Reader: strings.NewReader("hi")}
+	rec := &connectors.Record{
+		Pathname: "/etc/hello.txt",
+		Reader:   rc,
+	}
+
+	h.Track(rec)
+	got := h.Get(rec)
+	if got != rc {
+		t.Fatalf("Get did not return the same reader we Tracked")
+	}
+	// Second Get must return nil (entry removed)
+	if again := h.Get(rec); again != nil {
+		t.Fatalf("Get returned a non-nil reader after entry was claimed: %v", again)
+	}
+}
+
+func TestHoldingReaders_XattrKeySeparators(t *testing.T) {
+	h := NewHoldingReaders()
+
+	r1 := &countingReadCloser{Reader: strings.NewReader("a")}
+	r2 := &countingReadCloser{Reader: strings.NewReader("b")}
+
+	ext := &connectors.Record{
+		Pathname:  "/file",
+		IsXattr:   true,
+		XattrName: "user.x",
+		XattrType: objects.AttributeExtended,
+		Reader:    r1,
+	}
+	ads := &connectors.Record{
+		Pathname:  "/file",
+		IsXattr:   true,
+		XattrName: "user.x",
+		XattrType: objects.AttributeADS,
+		Reader:    r2,
+	}
+
+	h.Track(ext)
+	h.Track(ads)
+
+	if got := h.Get(ext); got != r1 {
+		t.Errorf("extended xattr lookup got the wrong reader")
+	}
+	if got := h.Get(ads); got != r2 {
+		t.Errorf("ADS xattr lookup got the wrong reader")
+	}
+}
+
+func TestHoldingReaders_CloseDrainsRemaining(t *testing.T) {
+	h := NewHoldingReaders()
+
+	rc1 := &countingReadCloser{Reader: strings.NewReader("x")}
+	rc2 := &countingReadCloser{Reader: strings.NewReader("y"), err: errors.New("boom")}
+
+	h.Track(&connectors.Record{Pathname: "/a", Reader: rc1})
+	h.Track(&connectors.Record{Pathname: "/b", Reader: rc2})
+
+	err := h.Close()
+	if !rc1.closed.Load() || !rc2.closed.Load() {
+		t.Fatalf("Close did not close all tracked readers: %v, %v", rc1.closed.Load(), rc2.closed.Load())
+	}
+	if err == nil {
+		t.Fatalf("Close should propagate the first non-nil close error")
+	}
+}
+
+func TestHoldingReaders_ConcurrentTrackGet(t *testing.T) {
+	h := NewHoldingReaders()
+
+	const N = 256
+	var wg sync.WaitGroup
+	wg.Add(2 * N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			rec := &connectors.Record{
+				Pathname: pathFor(i),
+				Reader:   &countingReadCloser{Reader: strings.NewReader("x")},
+			}
+			h.Track(rec)
+		}()
+		go func() {
+			defer wg.Done()
+			rec := &connectors.Record{Pathname: pathFor(i)}
+			_ = h.Get(rec)
+		}()
+	}
+	wg.Wait()
+}
+
+func pathFor(i int) string {
+	return "/p/" + itoa(i)
+}
+
+func itoa(n int) string {
+	// avoid strconv allocations in tight loops; tiny inline helper
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,313 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/PlakarKorp/kloset/connectors/storage"
+	"github.com/PlakarKorp/kloset/objects"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// ---------------------------------------------------------------------------
+// fakeServer
+// ---------------------------------------------------------------------------
+
+type fakeServer struct {
+	UnimplementedStoreServer
+
+	openConfig []byte
+	macs       [][]byte
+	getChunks  [][]byte
+	getErr     error
+	mode       int32
+
+	putBytes int64
+	putErr   error
+
+	receivedMac    []byte
+	receivedType   StorageResource
+	receivedChunks [][]byte
+}
+
+func (f *fakeServer) Init(ctx context.Context, req *InitRequest) (*InitResponse, error) {
+	return &InitResponse{Origin: "o", Type: "t", Root: "/"}, nil
+}
+func (f *fakeServer) Open(ctx context.Context, _ *OpenRequest) (*OpenResponse, error) {
+	return &OpenResponse{Config: f.openConfig}, nil
+}
+func (f *fakeServer) Create(ctx context.Context, _ *CreateRequest) (*CreateResponse, error) {
+	return &CreateResponse{}, nil
+}
+func (f *fakeServer) Ping(ctx context.Context, _ *PingRequest) (*PingResponse, error) {
+	return &PingResponse{}, nil
+}
+func (f *fakeServer) Close(ctx context.Context, _ *CloseRequest) (*CloseResponse, error) {
+	return &CloseResponse{}, nil
+}
+func (f *fakeServer) Mode(ctx context.Context, _ *ModeRequest) (*ModeResponse, error) {
+	return &ModeResponse{Mode: f.mode}, nil
+}
+func (f *fakeServer) Size(ctx context.Context, _ *SizeRequest) (*SizeResponse, error) {
+	return &SizeResponse{Size: 42}, nil
+}
+func (f *fakeServer) List(ctx context.Context, _ *ListRequest) (*ListResponse, error) {
+	return &ListResponse{Macs: f.macs}, nil
+}
+func (f *fakeServer) Delete(ctx context.Context, _ *DeleteRequest) (*DeleteResponse, error) {
+	return &DeleteResponse{}, nil
+}
+
+func (f *fakeServer) Put(stream grpc.ClientStreamingServer[PutRequest, PutResponse]) error {
+	for {
+		req, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if len(req.Mac) > 0 {
+			f.receivedMac = append([]byte(nil), req.Mac...)
+			f.receivedType = req.Type
+		}
+		if len(req.Chunk) > 0 {
+			f.receivedChunks = append(f.receivedChunks, append([]byte(nil), req.Chunk...))
+		}
+	}
+	if f.putErr != nil {
+		return f.putErr
+	}
+	return stream.SendAndClose(&PutResponse{BytesWritten: f.putBytes})
+}
+
+func (f *fakeServer) Get(_ *GetRequest, stream grpc.ServerStreamingServer[GetResponse]) error {
+	if f.getErr != nil {
+		return f.getErr
+	}
+	for _, c := range f.getChunks {
+		if err := stream.Send(&GetResponse{Chunk: c}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// scaffolding
+// ---------------------------------------------------------------------------
+
+func dialTestServer(t *testing.T, srv *fakeServer) (*grpc.ClientConn, func()) {
+	t.Helper()
+	lis := bufconn.Listen(1 << 20)
+	s := grpc.NewServer()
+	RegisterStoreServer(s, srv)
+	go func() { _ = s.Serve(lis) }()
+
+	conn, err := grpc.NewClient("passthrough://bufconn",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return conn, func() {
+		_ = conn.Close()
+		s.Stop()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestStore_BasicLifecycle(t *testing.T) {
+	srv := &fakeServer{openConfig: []byte("cfg")}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	s, err := NewStorage(context.Background(), conn, "p", nil)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	if cfg, err := s.Open(context.Background()); err != nil || string(cfg) != "cfg" {
+		t.Errorf("Open: %q %v", cfg, err)
+	}
+	if err := s.Create(context.Background(), []byte("x")); err != nil {
+		t.Errorf("Create: %v", err)
+	}
+	if err := s.Ping(context.Background()); err != nil {
+		t.Errorf("Ping: %v", err)
+	}
+	if size, err := s.Size(context.Background()); err != nil || size != 42 {
+		t.Errorf("Size: %d %v", size, err)
+	}
+	if err := s.Close(context.Background()); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestStore_List_ValidatesMacLength(t *testing.T) {
+	srv := &fakeServer{
+		macs: [][]byte{make([]byte, 16)},
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	s, _ := NewStorage(context.Background(), conn, "p", nil)
+	_, err := s.List(context.Background(), storage.StorageResourcePackfile)
+	if err == nil {
+		t.Fatalf("expected validation error for short MAC")
+	}
+}
+
+func TestStore_List_RoundTripsMacs(t *testing.T) {
+	full := bytes.Repeat([]byte{0x42}, 32)
+	srv := &fakeServer{macs: [][]byte{full}}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	s, _ := NewStorage(context.Background(), conn, "p", nil)
+	got, err := s.List(context.Background(), storage.StorageResourcePackfile)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0] != objects.MAC(full) {
+		t.Errorf("List mismatch: %v", got)
+	}
+}
+
+func TestStore_PutStreamsChunks(t *testing.T) {
+	srv := &fakeServer{putBytes: 11}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	s, _ := NewStorage(context.Background(), conn, "p", nil)
+
+	var mac objects.MAC
+	for i := range mac {
+		mac[i] = byte(i)
+	}
+	payload := []byte("hello world")
+	n, err := s.Put(context.Background(), storage.StorageResourcePackfile, mac, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if n != 11 {
+		t.Errorf("BytesWritten: %d, want 11", n)
+	}
+	if !bytes.Equal(srv.receivedMac, mac[:]) {
+		t.Errorf("mac mismatch")
+	}
+	var glued []byte
+	for _, c := range srv.receivedChunks {
+		glued = append(glued, c...)
+	}
+	if !bytes.Equal(glued, payload) {
+		t.Errorf("payload mismatch: %q vs %q", glued, payload)
+	}
+}
+
+func TestStore_GetStreamsChunks(t *testing.T) {
+	srv := &fakeServer{
+		getChunks: [][]byte{[]byte("foo"), []byte("bar"), []byte("baz")},
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	s, _ := NewStorage(context.Background(), conn, "p", nil)
+	rd, err := s.Get(context.Background(), storage.StorageResourcePackfile, objects.MAC{}, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rd.Close()
+	data, err := io.ReadAll(rd)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(data) != "foobarbaz" {
+		t.Errorf("payload mismatch: %q", data)
+	}
+}
+
+func TestStore_Get_UnavailableMapsToIOError(t *testing.T) {
+	srv := &fakeServer{
+		getErr: status.Error(codes.Unavailable, "down"),
+	}
+	conn, cleanup := dialTestServer(t, srv)
+	defer cleanup()
+
+	s, _ := NewStorage(context.Background(), conn, "p", nil)
+	rd, err := s.Get(context.Background(), storage.StorageResourcePackfile, objects.MAC{}, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rd.Close()
+
+	_, err = io.ReadAll(rd)
+	if err == nil {
+		t.Fatalf("expected error reading from server that returned Unavailable")
+	}
+}
+
+func TestSendChunks_PropagatesReadError(t *testing.T) {
+	rd := io.NopCloser(&errReader{err: errors.New("disk-on-fire")})
+	n, err := SendChunks(rd, func([]byte) error { return nil })
+	if n != 0 || err == nil {
+		t.Fatalf("expected read error, got n=%d err=%v", n, err)
+	}
+}
+
+func TestSendChunks_PropagatesSendError(t *testing.T) {
+	rd := io.NopCloser(bytes.NewReader([]byte("xxx")))
+	sendErr := errors.New("net dead")
+	_, err := SendChunks(rd, func([]byte) error { return sendErr })
+	if err == nil {
+		t.Fatalf("expected send error")
+	}
+}
+
+func TestReceiveChunks_ReassemblesAcrossChunkBoundaries(t *testing.T) {
+	chunks := [][]byte{[]byte("ab"), []byte("cde"), []byte("fghij")}
+	i := 0
+	rd := ReceiveChunks(func() ([]byte, error) {
+		if i >= len(chunks) {
+			return nil, io.EOF
+		}
+		c := chunks[i]
+		i++
+		return c, nil
+	})
+
+	// Read exactly 5 bytes at a time to force the buffer logic to span chunks.
+	buf := make([]byte, 5)
+	var out bytes.Buffer
+	for {
+		n, err := rd.Read(buf)
+		out.Write(buf[:n])
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+	}
+	if out.String() != "abcdefghij" {
+		t.Errorf("payload mismatch: %q", out.String())
+	}
+}
+
+type errReader struct{ err error }
+
+func (e *errReader) Read([]byte) (int, error) { return 0, e.err }


### PR DESCRIPTION
## Summary
- Adds 28 unit + integration tests across the five components of the repo (`conv`, `readers`, `importer`, `exporter`, `storage`). All pass under `go test -race ./...`.
- Uses `google.golang.org/grpc/test/bufconn` to spin up in-process fake gRPC servers for the importer/exporter/storage client wrappers.
- No production-code changes — pure test coverage, ready as a baseline for follow-up fixes.

## What's covered

- **`conv_test.go`** (7 tests): proto ↔ struct round-trip for regular files, error records (no FileInfo), xattr records, missing-FileInfo guard (`ErrInvalidRecord`), directories yielding no reader, nil-reader sentinel, full `Result` round-trip.
- **`readers_test.go`** (4 tests): `HoldingReaders` Track/Get/delete semantics, Extended vs ADS xattr key disambiguation, `Close()` propagating the first error while closing every tracked reader, a 256-goroutine concurrent stress test (validated under `-race`).
- **`importer/importer_test.go`** (5 tests): Init + getters (`FLAG_NEEDACK` assertion), `codes.Unavailable` → `"I/O error..."` mapping, `codes.Canceled` → `context.Canceled`, end-to-end Import streaming (records + lazy `Open` payload + ack drain), Open-error propagation through `LazyReader`.
- **`exporter/exporter_test.go`** (3 tests): Init + getters, full record-then-chunks-then-terminator send sequence verified against server-side reassembly + response stream, directory-record (no reader) skipping the chunk phase.
- **`storage/storage_test.go`** (9 tests): full unary lifecycle, `List` MAC-length validation, `List` 32-byte MAC round-trip, `Put` streaming with MAC + concatenated chunks observed server-side, `Get` reassembling multiple chunks, `Get` propagating `Unavailable`, `SendChunks` propagating read/send errors, `ReceiveChunks` reassembling across chunk boundaries when the caller reads smaller windows.

## Follow-ups (intentionally not in this PR)

While writing the tests, a number of correctness and robustness issues surfaced that should land as separate PRs. Briefly:

- `streamReader`/`grpcChunkReader` `Close()` drains the entire remaining stream synchronously — costly on large `Get` calls if the caller cancels mid-read; `grpcChunkReader.Close()` also doesn't cancel the context first.
- Import-side `Finished=true` semantics don't surface partial-ack loss when the transport dies between Finished and the last ack.
- `Exporter.transmitRecords` silently discards `record.Reader.Close()` errors.
- `unwrap` triplicated across the three sub-packages; loses gRPC `codes.Code` after stringification.
- Dead `cookie` fields in importer/exporter.
- A few smaller items (HoldingReaders Close idempotency, dead `io.EOF` branch in `Store.Put`, etc).

Happy to open a Wave-1 PR with the two correctness fixes (Close-drain + zero-length Read) plus their regression tests next.

## Test plan
- [x] `go test ./...` — 28 passed
- [x] `go test -race ./...` — 28 passed
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)